### PR TITLE
Invoice path relative to invoices_root_dir. Added invoice naming method.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 !/etc/build/.gitkeep
 
 /tests/Application/yarn.lock
+/.idea

--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,3 @@
 !/etc/build/.gitkeep
 
 /tests/Application/yarn.lock
-/.idea

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ theme path, in case you are using multiple themes.
   bitbag_sylius_invoicing_plugin.event_listener.order_show                                     BitBag\SyliusInvoicingPlugin\Menu\DownloadInvoiceMenuBuilder                                              
   bitbag_sylius_invoicing_plugin.factory.company_data                                          Sylius\Component\Resource\Factory\Factory                                                                 
   bitbag_sylius_invoicing_plugin.factory.invoice                                               Sylius\Component\Resource\Factory\Factory                                                                 
+  bitbag_sylius_invoicing_plugin.file_generator.invoice_filename                               BitBag\SyliusInvoicingPlugin\FileGenerator\InvoicePdfFilenameGenerator                                        
   bitbag_sylius_invoicing_plugin.file_generator.invoice_file                                   BitBag\SyliusInvoicingPlugin\FileGenerator\InvoicePdfFileGenerator                                        
   bitbag_sylius_invoicing_plugin.form.extension.address                                        BitBag\SyliusInvoicingPlugin\Form\Extension\AddressTypeExtension                                          
   bitbag_sylius_invoicing_plugin.form.type.company_data                                        BitBag\SyliusInvoicingPlugin\Form\Type\CompanyDataType                                                    

--- a/src/FileGenerator/FileGeneratorInterface.php
+++ b/src/FileGenerator/FileGeneratorInterface.php
@@ -19,7 +19,12 @@ interface FileGeneratorInterface
     /**
      * @param InvoiceInterface $invoice
      *
-     * @return string
+     * @return string Invoice filename
      */
     public function generateFile(InvoiceInterface $invoice): string;
+
+    /**
+     * @return string Absolute invoices folder path
+     */
+    public function getFilesPath(): string;
 }

--- a/src/FileGenerator/FileGeneratorInterface.php
+++ b/src/FileGenerator/FileGeneratorInterface.php
@@ -19,12 +19,12 @@ interface FileGeneratorInterface
     /**
      * @param InvoiceInterface $invoice
      *
-     * @return string Invoice filename
+     * @return string
      */
     public function generateFile(InvoiceInterface $invoice): string;
 
     /**
-     * @return string Absolute invoices folder path
+     * @return string
      */
     public function getFilesPath(): string;
 }

--- a/src/FileGenerator/FileGeneratorInterface.php
+++ b/src/FileGenerator/FileGeneratorInterface.php
@@ -26,5 +26,5 @@ interface FileGeneratorInterface
     /**
      * @return string
      */
-    public function getFilesPath(): string;
+    public function getFilesDirectoryPath(): string;
 }

--- a/src/FileGenerator/FilenameGeneratorInterface.php
+++ b/src/FileGenerator/FilenameGeneratorInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file has been created by developers from BitBag.
+ * Feel free to contact us once you face any issues or want to start
+ * another great project.
+ * You can find more information about us on https://bitbag.shop and write us
+ * an email on mikolaj.krol@bitbag.pl.
+ */
+
+declare(strict_types=1);
+
+namespace BitBag\SyliusInvoicingPlugin\FileGenerator;
+
+use BitBag\SyliusInvoicingPlugin\Entity\InvoiceInterface;
+
+interface FilenameGeneratorInterface
+{
+    /**
+     * @param InvoiceInterface $invoice
+     *
+     * @return string
+     */
+    public function generateFilename(InvoiceInterface $invoice): string;
+}

--- a/src/FileGenerator/InvoicePdfFileGenerator.php
+++ b/src/FileGenerator/InvoicePdfFileGenerator.php
@@ -68,10 +68,32 @@ final class InvoicePdfFileGenerator implements FileGeneratorInterface
                 'companyData' => $this->companyDataResolver->resolveCompanyData(),
             ]
         );
-        $path = $this->filesPath . '/' . (string) $invoice->getId() . bin2hex(random_bytes(6)) . '.pdf';
-
+        $filename = $this->getInvoiceFilename($invoice);
+        $path = $this->filesPath . DIRECTORY_SEPARATOR . $filename;
         $this->pdfFileGenerator->generateFromHtml($html, $path);
 
-        return $path;
+        return $filename;
+    }
+
+    /**
+     * @param InvoiceInterface $invoice
+     * @return string Returns an explicit invoice file name
+     */
+    protected function getInvoiceFilename(InvoiceInterface $invoice): string
+    {
+        $tokens = [
+            $invoice->getOrder()->getNumber(),
+            $invoice->getOrder()->getCreatedAt()->format('Ymd'),
+            bin2hex(random_bytes(6)),
+        ];
+        return (string) implode('_', $tokens) . '.pdf';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFilesPath(): string
+    {
+        return $this->filesPath;
     }
 }

--- a/src/FileGenerator/InvoicePdfFileGenerator.php
+++ b/src/FileGenerator/InvoicePdfFileGenerator.php
@@ -22,7 +22,7 @@ final class InvoicePdfFileGenerator implements FileGeneratorInterface
     /**
      * @var FilenameGeneratorInterface
      */
-    protected $filenameGenerator;
+    private $filenameGenerator;
 
     /**
      * @var GeneratorInterface
@@ -48,15 +48,15 @@ final class InvoicePdfFileGenerator implements FileGeneratorInterface
      * @param GeneratorInterface $pdfFileGenerator
      * @param EngineInterface $templatingEngine
      * @param CompanyDataResolverInterface $companyDataResolver
-     * @param string $filesPath
      * @param FilenameGeneratorInterface $filenameGenerator
+     * @param string $filesPath
      */
     public function __construct(
         GeneratorInterface $pdfFileGenerator,
         EngineInterface $templatingEngine,
         CompanyDataResolverInterface $companyDataResolver,
-        string $filesPath,
-        FilenameGeneratorInterface $filenameGenerator
+        FilenameGeneratorInterface $filenameGenerator,
+        string $filesPath
     ) {
         $this->pdfFileGenerator = $pdfFileGenerator;
         $this->templatingEngine = $templatingEngine;

--- a/src/FileGenerator/InvoicePdfFileGenerator.php
+++ b/src/FileGenerator/InvoicePdfFileGenerator.php
@@ -61,8 +61,8 @@ final class InvoicePdfFileGenerator implements FileGeneratorInterface
         $this->pdfFileGenerator = $pdfFileGenerator;
         $this->templatingEngine = $templatingEngine;
         $this->companyDataResolver = $companyDataResolver;
-        $this->filesPath = $filesPath;
         $this->filenameGenerator = $filenameGenerator;
+        $this->filesPath = $filesPath;
     }
 
     /**

--- a/src/FileGenerator/InvoicePdfFileGenerator.php
+++ b/src/FileGenerator/InvoicePdfFileGenerator.php
@@ -70,6 +70,7 @@ final class InvoicePdfFileGenerator implements FileGeneratorInterface
         );
         $filename = $this->getInvoiceFilename($invoice);
         $path = $this->filesPath . DIRECTORY_SEPARATOR . $filename;
+        
         $this->pdfFileGenerator->generateFromHtml($html, $path);
 
         return $filename;
@@ -86,6 +87,7 @@ final class InvoicePdfFileGenerator implements FileGeneratorInterface
             $invoice->getOrder()->getCreatedAt()->format('Ymd'),
             bin2hex(random_bytes(6)),
         ];
+
         return (string) implode('_', $tokens) . '.pdf';
     }
 

--- a/src/FileGenerator/InvoicePdfFileGenerator.php
+++ b/src/FileGenerator/InvoicePdfFileGenerator.php
@@ -78,6 +78,7 @@ final class InvoicePdfFileGenerator implements FileGeneratorInterface
 
     /**
      * @param InvoiceInterface $invoice
+     *
      * @return string Returns an explicit invoice file name
      */
     protected function getInvoiceFilename(InvoiceInterface $invoice): string
@@ -94,7 +95,7 @@ final class InvoicePdfFileGenerator implements FileGeneratorInterface
     /**
      * {@inheritdoc}
      */
-    public function getFilesPath(): string
+    public function getFilesDirectoryPath(): string
     {
         return $this->filesPath;
     }

--- a/src/FileGenerator/InvoicePdfFilenameGenerator.php
+++ b/src/FileGenerator/InvoicePdfFilenameGenerator.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file has been created by developers from BitBag.
+ * Feel free to contact us once you face any issues or want to start
+ * another great project.
+ * You can find more information about us on https://bitbag.shop and write us
+ * an email on mikolaj.krol@bitbag.pl.
+ */
+
+declare(strict_types=1);
+
+namespace BitBag\SyliusInvoicingPlugin\FileGenerator;
+
+use BitBag\SyliusInvoicingPlugin\Entity\InvoiceInterface;
+
+final class InvoicePdfFilenameGenerator implements FilenameGeneratorInterface
+{
+    /**
+     * @inheritDoc
+     */
+    public function generateFilename(InvoiceInterface $invoice): string
+    {
+        $tokens = [
+            $invoice->getOrder()->getNumber(),
+            $invoice->getOrder()->getCreatedAt()->format('Ymd'),
+            bin2hex(random_bytes(6)),
+        ];
+
+        return (string) implode('_', $tokens) . '.pdf';
+    }
+}

--- a/src/Resolver/InvoiceFileResolver.php
+++ b/src/Resolver/InvoiceFileResolver.php
@@ -63,13 +63,12 @@ final class InvoiceFileResolver implements InvoiceFileResolverInterface
     public function resolveInvoicePath(InvoiceInterface $invoice): string
     {
         if (null === $invoice->getPath() || (null !== $invoice->getPath() && 'prod' !== $this->environment)) {
-            $invoicePath = $this->invoiceFileGenerator->generateFile($invoice);
-
-            $invoice->setPath($invoicePath);
+            $invoiceFilename = $this->invoiceFileGenerator->generateFile($invoice);
+            $invoice->setPath($invoiceFilename);
 
             $this->invoiceEntityManager->flush();
         }
 
-        return $invoice->getPath();
+        return $this->invoiceFileGenerator->getFilesPath() . DIRECTORY_SEPARATOR . $invoice->getPath();
     }
 }

--- a/src/Resolver/InvoiceFileResolver.php
+++ b/src/Resolver/InvoiceFileResolver.php
@@ -69,6 +69,6 @@ final class InvoiceFileResolver implements InvoiceFileResolverInterface
             $this->invoiceEntityManager->flush();
         }
 
-        return $this->invoiceFileGenerator->getFilesPath() . DIRECTORY_SEPARATOR . $invoice->getPath();
+        return $this->invoiceFileGenerator->getFilesDirectoryPath() . DIRECTORY_SEPARATOR . $invoice->getPath();
     }
 }

--- a/src/Resolver/InvoiceFileResolver.php
+++ b/src/Resolver/InvoiceFileResolver.php
@@ -64,8 +64,8 @@ final class InvoiceFileResolver implements InvoiceFileResolverInterface
     {
         if (null === $invoice->getPath() || (null !== $invoice->getPath() && 'prod' !== $this->environment)) {
             $invoiceFilename = $this->invoiceFileGenerator->generateFile($invoice);
-            $invoice->setPath($invoiceFilename);
 
+            $invoice->setPath($invoiceFilename);
             $this->invoiceEntityManager->flush();
         }
 

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -14,8 +14,8 @@ services:
             - "@knp_snappy.pdf"
             - "@templating"
             - "@bitbag_sylius_invoicing_plugin.resolver.company_data"
-            - "%invoices_root_dir%"
             - "@bitbag_sylius_invoicing_plugin.file_generator.invoice_filename"
+            - "%invoices_root_dir%"
 
     bitbag_sylius_invoicing_plugin.validator.vat_number:
         class: BitBag\SyliusInvoicingPlugin\Validator\Constraints\VatNumberValidator

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -5,6 +5,9 @@ imports:
     - { resource: "@BitBagSyliusInvoicingPlugin/Resources/config/services/resolver.yml" }
 
 services:
+    bitbag_sylius_invoicing_plugin.file_generator.invoice_filename:
+        class: BitBag\SyliusInvoicingPlugin\FileGenerator\InvoicePdfFilenameGenerator
+
     bitbag_sylius_invoicing_plugin.file_generator.invoice_file:
         class: BitBag\SyliusInvoicingPlugin\FileGenerator\InvoicePdfFileGenerator
         arguments:
@@ -12,6 +15,7 @@ services:
             - "@templating"
             - "@bitbag_sylius_invoicing_plugin.resolver.company_data"
             - "%invoices_root_dir%"
+            - "@bitbag_sylius_invoicing_plugin.file_generator.invoice_filename"
 
     bitbag_sylius_invoicing_plugin.validator.vat_number:
         class: BitBag\SyliusInvoicingPlugin\Validator\Constraints\VatNumberValidator


### PR DESCRIPTION
- Invoice path relative to `invoices_root_dir` in order to store only important path info in database and make it portable.
- Added invoice naming method `getInvoiceFilename` which can be overridden if you want to change it.
- Added `getFilesPath` getter in `FileGeneratorInterface` to be able to get absolute invoices folder path from controllers.

See issue #4 

✌️Cheers!