### PR TITLE
Avoid failure in form event on customer account pages

### DIFF
--- a/src/Form/Extension/AddressTypeExtension.php
+++ b/src/Form/Extension/AddressTypeExtension.php
@@ -64,7 +64,12 @@ final class AddressTypeExtension extends AbstractTypeExtension
     {
         $builder
             ->addEventListener(FormEvents::PRE_SET_DATA, function (FormEvent $event): void {
-                $billingAddressForm = $event->getForm()->getParent()->get('billingAddress');
+                $parentForm = $event->getForm()->getParent()
+                if (null === $parentForm) {
+                    return;
+                }
+
+                $billingAddressForm = $parentForm->get('billingAddress');
 
                 if ($event->getForm() !== $billingAddressForm) {
                     return;


### PR DESCRIPTION
Fixes #8 

As reported, when trying to add/edit an address in the customer account, this event subscriber fails as there is no parent form defined.