### PR TITLE
Add the Content-Type header to the download response

### DIFF
--- a/src/Controller/Action/DownloadOrderInvoice.php
+++ b/src/Controller/Action/DownloadOrderInvoice.php
@@ -52,6 +52,7 @@ final class DownloadOrderInvoice
         $response = new BinaryFileResponse($this->invoiceFileResolver->resolveInvoicePath($invoice));
 
         $response->setContentDisposition(ResponseHeaderBag::DISPOSITION_ATTACHMENT);
+        $response->headers->set('Content-Type', 'application/pdf');
 
         return $response;
     }


### PR DESCRIPTION
Hi,
This PR explicitely sets the ContentType of the response so that Listeners plugged on the kernel.response can read it properly even though Response::prepare has not yet been called (this is the case in xynnn/google-tag-manager-bundle for instance)